### PR TITLE
fix(idempotence): Adjust google-chrome apt tasks for idempotence

### DIFF
--- a/roles/install/tasks/applications.yml
+++ b/roles/install/tasks/applications.yml
@@ -27,7 +27,7 @@
 
 - name: Check if google chrome repository is already listed in sources
   ansible.builtin.stat:
-    path: /etc/apt/sources.list.d/google_chrome.list
+    path: /etc/apt/sources.list.d/google-chrome.list
   register: google_chrome_repo
 
 - name: Add "google chrome" into repository sources list using specified filename

--- a/roles/install/tasks/applications.yml
+++ b/roles/install/tasks/applications.yml
@@ -25,15 +25,21 @@
   ansible.builtin.apt_key:
     url: https://dl.google.com/linux/linux_signing_key.pub
 
+- name: Check if google chrome repository is already listed in sources
+  ansible.builtin.stat:
+    path: /etc/apt/sources.list.d/google_chrome.list
+  register: google_chrome_repo
+
 - name: Add "google chrome" into repository sources list using specified filename
   ansible.builtin.apt_repository:
-    repo: deb http://dl.google.com/linux/chrome/deb/ stable main
+    repo: deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main
+    filename: google-chrome
     state: present
+  when: not google_chrome_repo.stat.exists
 
 - name: Install "google chrome"
   ansible.builtin.apt:
     name: google-chrome-stable
-    state: latest
     update_cache: true
 
 - name: Add firefox ppa repo

--- a/roles/install/tasks/apt-setup.yml
+++ b/roles/install/tasks/apt-setup.yml
@@ -10,6 +10,7 @@
       async: 600
       poll: 0
       register: update_and_upgrade_async
+      changed_when: "'molecule-idempotence-notest' not in ansible_skip_tags"
 
     - name: Wait until apt-get update/upgrade is complete (delay=5)
       ansible.builtin.async_status:
@@ -22,10 +23,3 @@
     - name: Output the result of update and upgade
       ansible.builtin.debug:
         var: update_and_upgrade_async_result
-
-    - name: Write the output of apt-get update/upgrade to /tmp/apt-get-output.log if changes ocurred # noqa: no-handler
-      ansible.builtin.copy:
-        content: "{{ update_and_upgrade_async_result.stdout }}"
-        dest: /tmp/apt-get-output.log
-        mode: "0644"
-      when: update_and_upgrade_async_result.changed


### PR DESCRIPTION
previously, two sources files were getting updated instead of one causing warnings